### PR TITLE
Fix nest-boss access rule

### DIFF
--- a/worlds/jakii/locs/mission_locations.py
+++ b/worlds/jakii/locs/mission_locations.py
@@ -291,7 +291,8 @@ main_mission_table = {
     65: Jak2MissionData(mission_id=65, task_id=74, name="Destroy Metal Kor at Nest",
                         rule=lambda state, player:
                         slums_to_nest(state, player)
-                        and state.has("Precursor Stone", player)
+                        and state.has_all(("Heart of Mar", "Time Map", "Rift Rider", "Precursor Stone", "Dark Jak"),
+                                          player)
                         and any_gun(state, player))
 }
 


### PR DESCRIPTION
## What is this fixing or adding?
In the mod, nest-boss-introduction requires the following:

```lisp
            :open? (lambda ((arg0 game-task-node-info)) 
              (and (ap-route-slums-to-nest?)
                   (logtesta? (-> *game-info* features) (game-feature gun precursor-stone darkjak rift-rider heart-of-mar time-map))
                   )
              )
```

Making the apworld follow suit.

## How was this tested?
Not tested.
